### PR TITLE
Add the Azure Boards badge to the README

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,3 +1,4 @@
+[![Board Status](https://dev.azure.com/pentest0614/00e6503c-dba9-4f15-9783-27a92e3391b6/dc56df31-6d14-456c-a501-8646f7140291/_apis/work/boardbadge/bb9b560d-0ea2-4fc5-8e4d-d54647a88997)](https://dev.azure.com/pentest0614/00e6503c-dba9-4f15-9783-27a92e3391b6/_boards/board/t/dc56df31-6d14-456c-a501-8646f7140291/Microsoft.RequirementCategory)
 
 # Haikus for Codespaces
 


### PR DESCRIPTION
Add the Azure Boards badge for the board used to track the work for this repository. Fixes [AB#1](https://dev.azure.com/pentest0614/00e6503c-dba9-4f15-9783-27a92e3391b6/_workitems/edit/1). See the [status badge configuration](https://aka.ms/azureboardsgithub-badge) documentation for more information.